### PR TITLE
Fix 'index out of range' error

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -3,11 +3,11 @@ description: Fearless SubQuery project
 repository: 'https://github.com/ef1rspb/subquery-fearless'
 schema: ./schema.graphql
 network:
-  endpoint: 'wss://rpc.polkadot.io'
+  endpoint: 'wss://kusama-rpc.polkadot.io'
 dataSources:
   - name: main
     kind: substrate/Runtime
-    startBlock: 5645004
+    startBlock: 8125620
 
     # polkadot test slash bloks: 3570179
 

--- a/src/mappings/Rewards.ts
+++ b/src/mappings/Rewards.ts
@@ -40,14 +40,14 @@ async function handleRewardForTxHistory(rewardEvent: SubstrateEvent): Promise<vo
     }
 
     let payoutCallsArgs = rewardEvent.block.block.extrinsics
-        .map(extrinsic => { return extrinsic.method })
+        .map(extrinsic => extrinsic.method)
         .map(determinePayoutCallsArgs)
-        .filter(args => {return args.length != 0})
+        .filter(args => args.length != 0)
         .flat()
 
-    const validators = new Array(
+    const validators = new Set(
         payoutCallsArgs.map(([validator,]) => validator)
-    ).flat()
+    )
 
     const initialCallIndex = -1
 
@@ -56,7 +56,7 @@ async function handleRewardForTxHistory(rewardEvent: SubstrateEvent): Promise<vo
         api.events.staking.Reward,
         initialCallIndex,
         (currentCallIndex, eventAccount) => {
-            return validators.includes(eventAccount) ? currentCallIndex + 1 : currentCallIndex
+            return validators.has(eventAccount) ? currentCallIndex + 1 : currentCallIndex
         },
         (currentCallIndex, amount) => {
             const [validator, era] = payoutCallsArgs[currentCallIndex]

--- a/src/mappings/Rewards.ts
+++ b/src/mappings/Rewards.ts
@@ -45,7 +45,7 @@ async function handleRewardForTxHistory(rewardEvent: SubstrateEvent): Promise<vo
         .filter(args => args.length != 0)
         .flat()
 
-    const validators = new Set(
+    const distinctValidators = new Set(
         payoutCallsArgs.map(([validator,]) => validator)
     )
 
@@ -56,7 +56,7 @@ async function handleRewardForTxHistory(rewardEvent: SubstrateEvent): Promise<vo
         api.events.staking.Reward,
         initialCallIndex,
         (currentCallIndex, eventAccount) => {
-            return validators.has(eventAccount) ? currentCallIndex + 1 : currentCallIndex
+            return distinctValidators.has(eventAccount) ? currentCallIndex + 1 : currentCallIndex
         },
         (currentCallIndex, amount) => {
             const [validator, era] = payoutCallsArgs[currentCallIndex]

--- a/src/mappings/Rewards.ts
+++ b/src/mappings/Rewards.ts
@@ -53,7 +53,8 @@ async function handleRewardForTxHistory(rewardEvent: SubstrateEvent): Promise<vo
         api.events.staking.Reward,
         initialCallIndex,
         (currentCallIndex, eventAccount) => {
-            return distinctValidators.has(eventAccount) ? currentCallIndex + 1 : currentCallIndex
+            let nextIndex = distinctValidators.has(eventAccount) ? currentCallIndex + 1 : currentCallIndex
+            return Math.min(nextIndex, payoutCallsArgs.length - 1)
         },
         (currentCallIndex, amount) => {
             const [validator, era] = payoutCallsArgs[currentCallIndex]


### PR DESCRIPTION
In this example `payoutCallArgs.length == 10` and we got error on `payoutCallArgs[10]`
<img width="1095" alt="Screenshot 2021-07-13 at 15 20 53" src="https://user-images.githubusercontent.com/17689921/125450950-e69197bd-1b7e-48f2-8504-1c693414ea34.png">

