### PR TITLE
Store Transfers at "transfer" property, not "extrinsic"

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -7,7 +7,7 @@ network:
 dataSources:
   - name: main
     kind: substrate/Runtime
-    startBlock: 5748206
+    startBlock: 6124033
 
     # polkadot test slash bloks: 3570179
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -5,6 +5,7 @@ type Transfer @jsonField {
   fee: String!
   block: String!
   extrinsicId: String
+  success: Boolean!
 }
 
 type Reward @jsonField {

--- a/src/mappings/HistoryElements.ts
+++ b/src/mappings/HistoryElements.ts
@@ -70,9 +70,9 @@ function findFailedTransferCalls(extrinsic: SubstrateExtrinsic): Transfer[] | nu
     return transferCallsArgs.map(tuple => {
         let blockNumber = extrinsic.block.block.header.number.toString()
         return {
-            amount: tuple[0],
+            amount: tuple[1].toString(),
             from: sender.toString(),
-            to: tuple[1].toString(),
+            to: tuple[0],
             block: blockNumber,
             fee: exportFeeFromDepositEvent(extrinsic).toString(),
             extrinsicId: eventIdFromBlockAndIdx(blockNumber, extrinsic.idx.toString()),

--- a/src/mappings/HistoryElements.ts
+++ b/src/mappings/HistoryElements.ts
@@ -1,10 +1,9 @@
 import {SubstrateEvent, SubstrateExtrinsic} from '@subql/types';
 import {HistoryElement, Transfer} from "../types";
 import {
-    blockNumber, callFromProxy, callsFromBatch, eventId,
-    eventIdFromBlockAndIdx,
+    callFromProxy, callsFromBatch,
     exportFeeFromDepositEvent,
-    extrinsicId, isBatch, isProxy,
+    extrinsicIdFromBlockAndIdx, isBatch, isProxy,
     isTransfer,
     timestamp
 } from "./common";
@@ -75,7 +74,7 @@ function findFailedTransferCalls(extrinsic: SubstrateExtrinsic): Transfer[] | nu
             to: tuple[0],
             block: blockNumber,
             fee: exportFeeFromDepositEvent(extrinsic).toString(),
-            extrinsicId: eventIdFromBlockAndIdx(blockNumber, extrinsic.idx.toString()),
+            extrinsicId: extrinsicIdFromBlockAndIdx(blockNumber, extrinsic.idx.toString()),
             success: false
         }
     })

--- a/src/mappings/HistoryElements.ts
+++ b/src/mappings/HistoryElements.ts
@@ -1,6 +1,14 @@
 import { SubstrateExtrinsic } from '@subql/types';
-import {HistoryElement} from "../types";
-import {exportFeeFromDepositEvent, timestamp} from "./common";
+import {HistoryElement, Transfer} from "../types";
+import {
+    blockNumber,
+    eventIdFromBlockAndIdx,
+    exportFeeFromDepositEvent,
+    extrinsicId,
+    isTransfer,
+    timestamp
+} from "./common";
+import {Balance} from "@polkadot/types/interfaces";
 
 export async function handleHistoryElement(extrinsic: SubstrateExtrinsic): Promise<void> {
     const { isSigned } = extrinsic.extrinsic;
@@ -9,14 +17,41 @@ export async function handleHistoryElement(extrinsic: SubstrateExtrinsic): Promi
         element.address = extrinsic.extrinsic.signer.toString()
         element.timestamp = timestamp(extrinsic.block)
 
-        element.extrinsic = {
-            hash: extrinsic.extrinsic.hash.toString(),
-            module: extrinsic.extrinsic.method.section,
-            call: extrinsic.extrinsic.method.method,
-            success: extrinsic.success,
-            fee: exportFeeFromDepositEvent(extrinsic)?.toString()
+        let transfer = findTransferCall(extrinsic)
+        if (transfer != undefined) {
+            element.transfer = transfer
+        } else {
+            element.extrinsic = {
+                hash: extrinsic.extrinsic.hash.toString(),
+                module: extrinsic.extrinsic.method.section,
+                call: extrinsic.extrinsic.method.method,
+                success: extrinsic.success,
+                fee: exportFeeFromDepositEvent(extrinsic)?.toString()
+            }
         }
 
         await element.save()
+    }
+}
+
+function findTransferCall(extrinsic: SubstrateExtrinsic): Transfer | null {
+    if (!isTransfer(extrinsic.extrinsic.method)) {
+        return null;
+    }
+
+    let args = extrinsic.extrinsic.args
+    let destination = args[0]
+    let amount = (args[1] as Balance).toBigInt()
+    let sender = extrinsic.extrinsic.signer
+
+    let blockNumber = extrinsic.block.block.header.number.toString()
+    return {
+        amount: amount.toString(),
+        from: sender.toString(),
+        to: destination.toString(),
+        block: blockNumber,
+        fee: exportFeeFromDepositEvent(extrinsic).toString(),
+        extrinsicId: eventIdFromBlockAndIdx(blockNumber, extrinsic.idx.toString()),
+        success: extrinsic.success
     }
 }

--- a/src/mappings/HistoryElements.ts
+++ b/src/mappings/HistoryElements.ts
@@ -1,57 +1,108 @@
-import { SubstrateExtrinsic } from '@subql/types';
+import {SubstrateEvent, SubstrateExtrinsic} from '@subql/types';
 import {HistoryElement, Transfer} from "../types";
 import {
-    blockNumber,
+    blockNumber, callFromProxy, callsFromBatch, eventId,
     eventIdFromBlockAndIdx,
     exportFeeFromDepositEvent,
-    extrinsicId,
+    extrinsicId, isBatch, isProxy,
     isTransfer,
     timestamp
 } from "./common";
 import {Balance} from "@polkadot/types/interfaces";
+import {CallBase} from "@polkadot/types/types/calls";
+import {AnyTuple} from "@polkadot/types/types/codec";
 
 export async function handleHistoryElement(extrinsic: SubstrateExtrinsic): Promise<void> {
     const { isSigned } = extrinsic.extrinsic;
     if (isSigned) {
-        const element = new HistoryElement(extrinsic.extrinsic.hash.toString());
-        element.address = extrinsic.extrinsic.signer.toString()
-        element.timestamp = timestamp(extrinsic.block)
-
-        let transfer = findTransferCall(extrinsic)
-        if (transfer != undefined) {
-            element.transfer = transfer
+        let failedTransfers = findFailedTransferCalls(extrinsic)
+        if (failedTransfers != null) {
+            await saveFailedTransfers(failedTransfers, extrinsic)
         } else {
-            element.extrinsic = {
-                hash: extrinsic.extrinsic.hash.toString(),
-                module: extrinsic.extrinsic.method.section,
-                call: extrinsic.extrinsic.method.method,
-                success: extrinsic.success,
-                fee: exportFeeFromDepositEvent(extrinsic)?.toString()
-            }
+            await saveExtrinsic(extrinsic)
         }
-
-        await element.save()
     }
 }
 
-function findTransferCall(extrinsic: SubstrateExtrinsic): Transfer | null {
-    if (!isTransfer(extrinsic.extrinsic.method)) {
+async function saveFailedTransfers(transfers: Transfer[], extrinsic: SubstrateExtrinsic): Promise<void> {
+    let promises = transfers.map(transfer => {
+        const elementFrom = new HistoryElement(transfer.extrinsicId+`-from`);
+        elementFrom.address = transfer.from
+        elementFrom.timestamp = timestamp(extrinsic.block)
+        elementFrom.transfer = transfer
+
+        const elementTo = new HistoryElement(transfer.extrinsicId+`-to`);
+        elementTo.address = transfer.to
+        elementTo.timestamp = timestamp(extrinsic.block)
+        elementTo.transfer = transfer
+
+        return [elementTo.save(), elementFrom.save()]
+    })
+    await Promise.allSettled(promises)
+}
+
+async function saveExtrinsic(extrinsic: SubstrateExtrinsic): Promise<void> {
+    const element = new HistoryElement(extrinsic.extrinsic.hash.toString());
+    element.address = extrinsic.extrinsic.signer.toString()
+    element.timestamp = timestamp(extrinsic.block)
+    element.extrinsic = {
+        hash: extrinsic.extrinsic.hash.toString(),
+        module: extrinsic.extrinsic.method.section,
+        call: extrinsic.extrinsic.method.method,
+        success: extrinsic.success,
+        fee: exportFeeFromDepositEvent(extrinsic)?.toString()
+    }
+    await element.save()
+}
+
+/// Success Transfer emits Transfer event that is handled at Transfers.ts handleTransfer()
+function findFailedTransferCalls(extrinsic: SubstrateExtrinsic): Transfer[] | null {
+    if (extrinsic.success) {
         return null;
     }
 
-    let args = extrinsic.extrinsic.args
-    let destination = args[0]
-    let amount = (args[1] as Balance).toBigInt()
-    let sender = extrinsic.extrinsic.signer
-
-    let blockNumber = extrinsic.block.block.header.number.toString()
-    return {
-        amount: amount.toString(),
-        from: sender.toString(),
-        to: destination.toString(),
-        block: blockNumber,
-        fee: exportFeeFromDepositEvent(extrinsic).toString(),
-        extrinsicId: eventIdFromBlockAndIdx(blockNumber, extrinsic.idx.toString()),
-        success: extrinsic.success
+    let transferCallsArgs = determineTransferCallsArgs(extrinsic.extrinsic.method)
+    if (transferCallsArgs.length == 0) {
+        return null;
     }
+
+    let sender = extrinsic.extrinsic.signer
+    return transferCallsArgs.map(tuple => {
+        let blockNumber = extrinsic.block.block.header.number.toString()
+        return {
+            amount: tuple[0],
+            from: sender.toString(),
+            to: tuple[1].toString(),
+            block: blockNumber,
+            fee: exportFeeFromDepositEvent(extrinsic).toString(),
+            extrinsicId: eventIdFromBlockAndIdx(blockNumber, extrinsic.idx.toString()),
+            success: false
+        }
+    })
+}
+
+function determineTransferCallsArgs(causeCall: CallBase<AnyTuple>) : [string, number][] {
+    if (isTransfer(causeCall)) {
+        return [extractArgsFromTransfer(causeCall)]
+    } else if (isBatch(causeCall)) {
+        return callsFromBatch(causeCall)
+            .map(call => {
+                return determineTransferCallsArgs(call)
+                    .map((value, index, array) => {
+                        return value
+                    })
+            })
+            .flat()
+    } else if (isProxy(causeCall)) {
+        let proxyCall = callFromProxy(causeCall)
+        return determineTransferCallsArgs(proxyCall)
+    } else {
+        return []
+    }
+}
+
+function extractArgsFromTransfer(call: CallBase<AnyTuple>): [string, number] {
+    const [destinationAddress, amount] = call.args
+
+    return [destinationAddress.toString(), (amount as Balance).toNumber()]
 }

--- a/src/mappings/Transfers.ts
+++ b/src/mappings/Transfers.ts
@@ -28,7 +28,8 @@ async function populateTransfer(element: HistoryElement, event: SubstrateEvent):
         to: to.toString(),
         block: blockNumber(event),
         fee: exportFeeFromDepositEvent(event.extrinsic).toString(),
-        extrinsicId: extrinsicId(event)
+        extrinsicId: extrinsicId(event),
+        success: true
     }
     await element.save();
 }

--- a/src/mappings/common.ts
+++ b/src/mappings/common.ts
@@ -50,6 +50,10 @@ export function blockNumber(event: SubstrateEvent): string {
     return event.block.block.header.number.toString()
 }
 
+export function extrinsicIdFromBlockAndIdx(blockNumber: string, eventIdx: string) {
+    return `${blockNumber}-${eventIdx}`
+}
+
 export function timestamp(block: SubstrateBlock): string {
     return Math.round((block.timestamp.getTime() / 1000)).toString()
 }

--- a/src/mappings/common.ts
+++ b/src/mappings/common.ts
@@ -8,6 +8,7 @@ import {EventRecord} from "@polkadot/types/interfaces/system/types"
 
 
 const batchCalls = ["batch", "batchAll"]
+const transferCalls = ["transfer", "transferKeepAlive"]
 
 export function distinct<T>(array: Array<T>): Array<T> {
     return [...new Set(array)];
@@ -19,6 +20,10 @@ export function isBatch(call: CallBase<AnyTuple>) : boolean {
 
 export function isProxy(call: CallBase<AnyTuple>) : boolean {
     return call.section == "proxy" && call.method == "proxy"
+}
+
+export function isTransfer(call: CallBase<AnyTuple>) : boolean {
+    return call.section == "balances" && transferCalls.includes(call.method)
 }
 
 export function callsFromBatch(batchCall: CallBase<AnyTuple>) : CallBase<AnyTuple>[] {


### PR DESCRIPTION
```
          {
            "id": "6071483-1-from",
            "timestamp": "1627094706",
            "transfer": {
              "to": "10000000000",
              "fee": "31200003",
              "from": "1gZL8r8LLtSixq3387n4ZHiTEJ6qwfz235nXgKA3QQkeVNh",
              "block": "6071483",
              "amount": "1RQJSs5YMfpXNBTAxmBw8r4d6fB3EYi78V14GGmdu6XdHkt",
              "success": false,
              "extrinsicId": "6071483-1"
            },
            "reward": null,
            "extrinsic": null,
            "address": "1gZL8r8LLtSixq3387n4ZHiTEJ6qwfz235nXgKA3QQkeVNh"
          },
          {
            "id": "6071483-1-to",
            "timestamp": "1627094706",
            "transfer": {
              "to": "10000000000",
              "fee": "31200003",
              "from": "1gZL8r8LLtSixq3387n4ZHiTEJ6qwfz235nXgKA3QQkeVNh",
              "block": "6071483",
              "amount": "1RQJSs5YMfpXNBTAxmBw8r4d6fB3EYi78V14GGmdu6XdHkt",
              "success": false,
              "extrinsicId": "6071483-1"
            },
            "reward": null,
            "extrinsic": null,
            "address": "10000000000"
          },
```