### PR TITLE
Fix error: Number can only safely store up to 53 bits at assert

### DIFF
--- a/src/mappings/HistoryElements.ts
+++ b/src/mappings/HistoryElements.ts
@@ -10,6 +10,7 @@ import {
 import {Balance} from "@polkadot/types/interfaces";
 import {CallBase} from "@polkadot/types/types/calls";
 import {AnyTuple} from "@polkadot/types/types/codec";
+import {u64} from "@polkadot/types";
 
 export async function handleHistoryElement(extrinsic: SubstrateExtrinsic): Promise<void> {
     const { isSigned } = extrinsic.extrinsic;
@@ -103,5 +104,5 @@ function determineTransferCallsArgs(causeCall: CallBase<AnyTuple>) : [string, bi
 function extractArgsFromTransfer(call: CallBase<AnyTuple>): [string, bigint] {
     const [destinationAddress, amount] = call.args
 
-    return [destinationAddress.toString(), (amount as Balance).toBigInt()]
+    return [destinationAddress.toString(), (amount as u64).toBigInt()]
 }

--- a/src/mappings/HistoryElements.ts
+++ b/src/mappings/HistoryElements.ts
@@ -80,7 +80,7 @@ function findFailedTransferCalls(extrinsic: SubstrateExtrinsic): Transfer[] | nu
     })
 }
 
-function determineTransferCallsArgs(causeCall: CallBase<AnyTuple>) : [string, number][] {
+function determineTransferCallsArgs(causeCall: CallBase<AnyTuple>) : [string, bigint][] {
     if (isTransfer(causeCall)) {
         return [extractArgsFromTransfer(causeCall)]
     } else if (isBatch(causeCall)) {
@@ -100,8 +100,8 @@ function determineTransferCallsArgs(causeCall: CallBase<AnyTuple>) : [string, nu
     }
 }
 
-function extractArgsFromTransfer(call: CallBase<AnyTuple>): [string, number] {
+function extractArgsFromTransfer(call: CallBase<AnyTuple>): [string, bigint] {
     const [destinationAddress, amount] = call.args
 
-    return [destinationAddress.toString(), (amount as Balance).toNumber()]
+    return [destinationAddress.toString(), (amount as Balance).toBigInt()]
 }


### PR DESCRIPTION
Failed on Polkadot: https://polkadot.subscan.io/extrinsic/305849-2
Failed on Kusama: https://kusama.subscan.io/extrinsic/1724531-2
Amount is too big for `number` type, so we have to cast to u64
Result:
```
Kusama
      {
            "id": "1724531-2-from",
            "timestamp": "1585894392",
            "transfer": {
              "to": "HsWN6mjakUvuYjYoQauuiJhrSBtcup9M66X4YQasx5HZNYS",
              "fee": "2000000000",
              "from": "EQT4bZ6i2drETLmHhyn9Xd5xD78bpxaDhZVru16eWZ42tkZ",
              "block": "1724531",
              "amount": "999999000000000000",
              "success": false,
              "extrinsicId": "1724531-2"
            },
            "reward": null,
            "extrinsic": null,
            "address": "EQT4bZ6i2drETLmHhyn9Xd5xD78bpxaDhZVru16eWZ42tkZ"
          },
          {
            "id": "1724531-2-to",
            "timestamp": "1585894392",
            "transfer": {
              "to": "HsWN6mjakUvuYjYoQauuiJhrSBtcup9M66X4YQasx5HZNYS",
              "fee": "2000000000",
              "from": "EQT4bZ6i2drETLmHhyn9Xd5xD78bpxaDhZVru16eWZ42tkZ",
              "block": "1724531",
              "amount": "999999000000000000",
              "success": false,
              "extrinsicId": "1724531-2"
            },
            "reward": null,
            "extrinsic": null,
            "address": "HsWN6mjakUvuYjYoQauuiJhrSBtcup9M66X4YQasx5HZNYS"
          },

Polkadot:
       {
            "id": "305849-2-from",
            "timestamp": "1592342736",
            "transfer": {
              "to": "1jpMmWDSqYDQcgjTkvHyga2XHESEKGY8BgHe4jBmxE4eddK",
              "fee": "2000000",
              "from": "152ob6PDAKjdi5WT8Dm83TLMuoehVyUveCAafjq5XVXc4nYy",
              "block": "305849",
              "amount": "116358000000000000",
              "success": false,
              "extrinsicId": "305849-2"
            },
            "reward": null,
            "extrinsic": null,
            "address": "152ob6PDAKjdi5WT8Dm83TLMuoehVyUveCAafjq5XVXc4nYy"
          },
          {
            "id": "305849-2-to",
            "timestamp": "1592342736",
            "transfer": {
              "to": "1jpMmWDSqYDQcgjTkvHyga2XHESEKGY8BgHe4jBmxE4eddK",
              "fee": "2000000",
              "from": "152ob6PDAKjdi5WT8Dm83TLMuoehVyUveCAafjq5XVXc4nYy",
              "block": "305849",
              "amount": "116358000000000000",
              "success": false,
              "extrinsicId": "305849-2"
            },
            "reward": null,
            "extrinsic": null,
            "address": "1jpMmWDSqYDQcgjTkvHyga2XHESEKGY8BgHe4jBmxE4eddK"
          },
```