### PR TITLE
Add support for payout_validator extrinsic

### DIFF
--- a/src/mappings/Rewards.ts
+++ b/src/mappings/Rewards.ts
@@ -30,7 +30,7 @@ export async function handleReward(rewardEvent: SubstrateEvent): Promise<void> {
     let rewardEventId = eventId(rewardEvent)
     try {
         let errorOccursOnEvent = await ErrorEvent.get(rewardEventId)
-        if (errorOccursOnEvent != undefined) {
+        if (errorOccursOnEvent !== undefined) {
             logger.info(`Skip rewardEvent: ${rewardEventId}`)
             return;
         }
@@ -38,7 +38,7 @@ export async function handleReward(rewardEvent: SubstrateEvent): Promise<void> {
         await handleRewardRestakeForAnalytics(rewardEvent)
         await handleRewardForTxHistory(rewardEvent)
     } catch (error) {
-        logger.error(`Got error on event: ${rewardEventId}: ${error.toString()}`)
+        logger.error(`Got error on reward event: ${rewardEventId}: ${error.toString()}`)
         let saveError = new ErrorEvent(rewardEventId)
         saveError.description = error.toString()
         await saveError.save()
@@ -48,7 +48,7 @@ export async function handleReward(rewardEvent: SubstrateEvent): Promise<void> {
 async function handleRewardForTxHistory(rewardEvent: SubstrateEvent): Promise<void> {
     let element = await HistoryElement.get(eventId(rewardEvent))
 
-    if (element != undefined) {
+    if (element !== undefined) {
         // already processed reward previously
         return;
     }
@@ -58,6 +58,10 @@ async function handleRewardForTxHistory(rewardEvent: SubstrateEvent): Promise<vo
         .map(determinePayoutCallsArgs)
         .filter(args => args.length != 0)
         .flat()
+
+    if (payoutCallsArgs.length == 0) {
+        return
+    }
 
     const distinctValidators = new Set(
         payoutCallsArgs.map(([validator,]) => validator)
@@ -109,7 +113,7 @@ export async function handleSlash(slashEvent: SubstrateEvent): Promise<void> {
     let slashEventId = eventId(slashEvent)
     try {
         let errorOccursOnEvent = await ErrorEvent.get(slashEventId)
-        if (errorOccursOnEvent != undefined) {
+        if (errorOccursOnEvent !== undefined) {
             logger.info(`Skip slashEvent: ${slashEventId}`)
             return;
         }
@@ -117,7 +121,7 @@ export async function handleSlash(slashEvent: SubstrateEvent): Promise<void> {
         await handleSlashForAnalytics(slashEvent)
         await handleSlashForTxHistory(slashEvent)
     } catch (error) {
-        logger.error(`Got error on event: ${slashEventId}: ${error.toString()}`)
+        logger.error(`Got error on slash event: ${slashEventId}: ${error.toString()}`)
         let saveError = new ErrorEvent(slashEventId)
         saveError.description = error.toString()
         await saveError.save()
@@ -127,7 +131,7 @@ export async function handleSlash(slashEvent: SubstrateEvent): Promise<void> {
 async function handleSlashForTxHistory(slashEvent: SubstrateEvent): Promise<void> {
     let element = await HistoryElement.get(eventId(slashEvent))
 
-    if (element != undefined) {
+    if (element !== undefined) {
         // already processed reward previously
         return;
     }

--- a/src/mappings/StakeChanged.ts
+++ b/src/mappings/StakeChanged.ts
@@ -77,7 +77,7 @@ export async function handleRewardRestakeForAnalytics(event: SubstrateEvent): Pr
 
 async function handleAccumulatedStake(address: string, amount: bigint): Promise<bigint> {
     let accumulatedStake = await AccumulatedStake.get(address)
-    if (accumulatedStake != undefined) {
+    if (accumulatedStake !== undefined) {
         let accumulatedAmount = BigInt(accumulatedStake.amount).valueOf()
         accumulatedAmount += amount
         accumulatedStake.amount = accumulatedAmount.toString()


### PR DESCRIPTION
**Problem:** SubQuery indexer is stuck on block https://kusama.subscan.io/block/1976147?tab=event
In specVersion 1055 there was a `payout_validator` extrinsic https://kusama.subscan.io/runtime/Staking?version=1055
 so we can't extract payoutCallArgs (is empty), 
but we create Set from empty array => got error: ` TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))`
<img width="1008" alt="Screenshot 2021-08-02 at 21 08 50" src="https://user-images.githubusercontent.com/17689921/127905120-5ebad9a6-833d-4f52-9ba1-1e7769aac773.png">
**Solution:** Add support for `payout_validator` extrinsic, early return from function if we can't extract data
