### PR TITLE
Fix undefined slashDeferDuration for older specVersions

### DIFF
--- a/src/mappings/Rewards.ts
+++ b/src/mappings/Rewards.ts
@@ -205,7 +205,9 @@ async function handleSlashForTxHistory(slashEvent: SubstrateEvent): Promise<void
     const currentEra = (await api.query.staking.currentEra()).unwrap()
     const slashDeferDuration = api.consts.staking.slashDeferDuration
 
-    const slashEra = currentEra.toNumber() - slashDeferDuration.toNumber()
+    const slashEra = slashDeferDuration == undefined 
+    ? currentEra.toNumber()
+    : currentEra.toNumber() - slashDeferDuration.toNumber()
 
     const eraStakersInSlashEra = await api.query.staking.erasStakersClipped.entries(slashEra);
     const validatorsInSlashEra = eraStakersInSlashEra.map(([key, exposure]) => {


### PR DESCRIPTION
On westend staging project:
```
failed to index block at height 260481 
handleSlash([{"phase":{"initialization":null},"event":{"index":"0x0302","data":["5E9rpNRcZnecoL5n67oHpZCwR1hbfL1jyCH8g4P3TgH12TcD",2999999900]},"topics":[]}])
 TypeError: Cannot read property 'toNumber' of undefined at handleSlashForTxHistory
```