### PR TITLE
Fix: empty eraValidatorInfos on Asset Hub after staking-async upgrade

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,5 +16,7 @@ jobs:
         run: yarn install
       - name: Codegen
         run: yarn codegen
+      - name: Test
+        run: yarn test
       - name: Build
         run: yarn build

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,4 +1,10 @@
 export default {
   preset: "ts-jest",
   testMatch: ["**/tests/**/*.test.ts"],
+  transform: {
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      { tsconfig: "tsconfig.jest.json", diagnostics: false },
+    ],
+  },
 };

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "./node_modules/.bin/subql build",
     "start:docker": "docker-compose pull && docker-compose up --remove-orphans",
     "codegen": "./node_modules/.bin/subql codegen",
+    "test": "jest",
     "validate": "./node_modules/.bin/subql validate",
     "prepare": "husky install",
     "local-publish": "cd ./scripts && ./local-publish.sh"

--- a/scripts/backfill_era_validator_infos.js
+++ b/scripts/backfill_era_validator_infos.js
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+/**
+ * Backfills the era_validator_infos table from current on-chain state.
+ *
+ * Asset Hub indexers stopped saving EraValidatorInfo after the staking-async
+ * runtime upgrade (see handlePagedElectionProceeded in src/mappings/NewEra.ts).
+ * The chain keeps exposures for the last `historyDepth` (84) eras in state, so
+ * the missing part of the payout window can be restored without reindexing.
+ *
+ * The script reads erasStakersOverview/erasStakersPaged for each era in the
+ * range and generates a SQL file with idempotent INSERTs (ON CONFLICT DO
+ * NOTHING), to be applied with psql against the project database:
+ *
+ *   node scripts/backfill_era_validator_infos.js \
+ *     --ws wss://asset-hub-polkadot-rpc.n.dwellir.com \
+ *     --out polkadot-ah-backfill.sql \
+ *     [--from 2144] [--to 2227] [--schema app] [--no-timestamps]
+ *
+ *   psql -h <host> -p <port> -U <user> -d <db> -f polkadot-ah-backfill.sql
+ *
+ * Defaults: from = currentEra - historyDepth, to = currentEra, schema = app.
+ * Eras whose exposures are already pruned from state are skipped with a warning.
+ * Row ids use the `<era>-backfill-<validator>` format so they never collide
+ * with handler-written rows (`<block>-<eventIdx><validator>`).
+ */
+
+const { ApiPromise, WsProvider } = require("@polkadot/api");
+const fs = require("fs");
+
+function parseArgs() {
+  const args = { schema: "app", timestamps: true };
+  const argv = process.argv.slice(2);
+  for (let i = 0; i < argv.length; i++) {
+    switch (argv[i]) {
+      case "--ws":
+        args.ws = argv[++i];
+        break;
+      case "--out":
+        args.out = argv[++i];
+        break;
+      case "--from":
+        args.from = parseInt(argv[++i], 10);
+        break;
+      case "--to":
+        args.to = parseInt(argv[++i], 10);
+        break;
+      case "--schema":
+        args.schema = argv[++i];
+        break;
+      case "--no-timestamps":
+        args.timestamps = false;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${argv[i]}`);
+    }
+  }
+  if (!args.ws || !args.out) {
+    throw new Error(
+      "Usage: backfill_era_validator_infos.js --ws <endpoint> --out <file.sql> [--from <era>] [--to <era>] [--schema app] [--no-timestamps]",
+    );
+  }
+  return args;
+}
+
+function sqlString(value) {
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+async function fetchEraRows(api, era) {
+  const overview = await api.query.staking.erasStakersOverview.entries(era);
+  if (overview.length === 0) {
+    return [];
+  }
+  const pages = await api.query.staking.erasStakersPaged.entries(era);
+
+  const othersByValidator = {};
+  for (const [key, exp] of pages) {
+    const [, validatorId, pageId] = key.args;
+    const validator = validatorId.toString();
+    const others = exp.unwrap().others.map(({ who, value }) => {
+      return { who: who.toString(), value: value.toString() };
+    });
+    (othersByValidator[validator] = othersByValidator[validator] || {})[
+      pageId.toNumber()
+    ] = others;
+  }
+
+  return overview.map(([key, exp]) => {
+    const [, validatorId] = key.args;
+    const validator = validatorId.toString();
+    const exposure = exp.unwrap();
+
+    const others = [];
+    const pageMap = othersByValidator[validator] || {};
+    for (let page = 0; page < exposure.pageCount.toNumber(); page++) {
+      if (pageMap[page]) {
+        others.push(...pageMap[page]);
+      } else {
+        console.warn(
+          `warning: missing page ${page} for validator ${validator} in era ${era}`,
+        );
+      }
+    }
+
+    return {
+      id: `${era}-backfill-${validator}`,
+      address: validator,
+      era: era,
+      total: exposure.total.toBigInt().toString(),
+      own: exposure.own.toBigInt().toString(),
+      others: others,
+    };
+  });
+}
+
+function rowsToSql(rows, schema, timestamps) {
+  const columns = ["id", "address", "era", "total", "own", "others"];
+  if (timestamps) {
+    columns.push("created_at", "updated_at");
+  }
+  const values = rows
+    .map((row) => {
+      const value = [
+        sqlString(row.id),
+        sqlString(row.address),
+        row.era,
+        row.total,
+        row.own,
+        `${sqlString(JSON.stringify(row.others))}::jsonb`,
+      ];
+      if (timestamps) {
+        value.push("now()", "now()");
+      }
+      return `(${value.join(", ")})`;
+    })
+    .join(",\n");
+
+  return (
+    `INSERT INTO "${schema}".era_validator_infos (${columns.join(", ")})\n` +
+    `VALUES\n${values}\nON CONFLICT (id) DO NOTHING;\n\n`
+  );
+}
+
+async function main() {
+  const args = parseArgs();
+
+  const api = await ApiPromise.create({ provider: new WsProvider(args.ws) });
+
+  const currentEra = (await api.query.staking.currentEra()).unwrap().toNumber();
+  const historyDepth = api.consts.staking.historyDepth.toNumber();
+  const from = args.from ?? currentEra - historyDepth;
+  const to = args.to ?? currentEra;
+  console.log(
+    `currentEra=${currentEra} historyDepth=${historyDepth}; backfilling eras ${from}..${to} into "${args.schema}".era_validator_infos`,
+  );
+
+  const out = fs.createWriteStream(args.out);
+  out.write(
+    `-- era_validator_infos backfill generated by scripts/backfill_era_validator_infos.js\n` +
+      `-- endpoint: ${args.ws}, eras: ${from}..${to}\n\n`,
+  );
+
+  let totalRows = 0;
+  const skipped = [];
+  for (let era = from; era <= to; era++) {
+    const rows = await fetchEraRows(api, era);
+    if (rows.length === 0) {
+      skipped.push(era);
+      console.warn(`era ${era}: no exposures in state (pruned?), skipping`);
+      continue;
+    }
+    out.write(rowsToSql(rows, args.schema, args.timestamps));
+    totalRows += rows.length;
+    console.log(`era ${era}: ${rows.length} validators`);
+  }
+
+  await new Promise((resolve) => out.end(resolve));
+  console.log(
+    `done: ${totalRows} rows written to ${args.out}` +
+      (skipped.length > 0 ? `; skipped eras: ${skipped.join(", ")}` : ""),
+  );
+  process.exit(0);
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/scripts/backfill_era_validator_infos.js
+++ b/scripts/backfill_era_validator_infos.js
@@ -14,11 +14,12 @@
  *   node scripts/backfill_era_validator_infos.js \
  *     --ws wss://asset-hub-polkadot-rpc.n.dwellir.com \
  *     --out polkadot-ah-backfill.sql \
- *     [--from 2144] [--to 2227] [--schema app] [--no-timestamps]
+ *     [--from 2144] [--to 2227] [--schema app] [--timestamps]
  *
  *   psql -h <host> -p <port> -U <user> -d <db> -f polkadot-ah-backfill.sql
  *
  * Defaults: from = currentEra - historyDepth, to = currentEra, schema = app.
+ * Deployed tables have no created_at/updated_at columns; pass --timestamps if yours do.
  * Eras whose exposures are already pruned from state are skipped with a warning.
  * Row ids use the `<era>-backfill-<validator>` format so they never collide
  * with handler-written rows (`<block>-<eventIdx><validator>`).
@@ -28,7 +29,7 @@ const { ApiPromise, WsProvider } = require("@polkadot/api");
 const fs = require("fs");
 
 function parseArgs() {
-  const args = { schema: "app", timestamps: true };
+  const args = { schema: "app", timestamps: false };
   const argv = process.argv.slice(2);
   for (let i = 0; i < argv.length; i++) {
     switch (argv[i]) {
@@ -47,8 +48,8 @@ function parseArgs() {
       case "--schema":
         args.schema = argv[++i];
         break;
-      case "--no-timestamps":
-        args.timestamps = false;
+      case "--timestamps":
+        args.timestamps = true;
         break;
       default:
         throw new Error(`Unknown argument: ${argv[i]}`);
@@ -56,7 +57,7 @@ function parseArgs() {
   }
   if (!args.ws || !args.out) {
     throw new Error(
-      "Usage: backfill_era_validator_infos.js --ws <endpoint> --out <file.sql> [--from <era>] [--to <era>] [--schema app] [--no-timestamps]",
+      "Usage: backfill_era_validator_infos.js --ws <endpoint> --out <file.sql> [--from <era>] [--to <era>] [--schema app] [--timestamps]",
     );
   }
   return args;

--- a/src/mappings/NewEra.ts
+++ b/src/mappings/NewEra.ts
@@ -31,16 +31,21 @@ export async function handleStakersElected(
 //
 // Therefore at the EraPaid block exposures(activeEra) are guaranteed complete - an era
 // cannot start without its full validator set. Snapshot activeEra here.
-// getByEra guards against double-writes (backfill, reindex).
-export async function handleAHEraPaid(event: SubstrateEvent): Promise<void> {
+// The era-exists check guards against double-writes (backfill, reindex).
+export async function handleAHEraPaid(_: SubstrateEvent): Promise<void> {
   const activeEra = (
     (await api.query.staking.activeEra()) as Option<PalletStakingActiveEraInfo>
   )
     .unwrap()
     .index.toNumber();
 
-  const existing = await EraValidatorInfo.getByEra(activeEra);
-  if (existing !== undefined && existing.length > 0) {
+  const existing = await EraValidatorInfo.getByFields(
+    [["era", "=", activeEra]],
+    {
+      limit: 1,
+    },
+  );
+  if (existing.length > 0) {
     return;
   }
 
@@ -124,9 +129,18 @@ async function processEraStakersPaged(currentEra: number): Promise<void> {
     const [, validatorId] = key.args;
     let validatorIdString = validatorId.toString();
 
+    // Fail fast on incomplete exposures: a missing page means the on-chain
+    // invariant is broken, and halting the indexer is better than saving
+    // partial nominator sets silently.
     let others = [];
     for (let i = 0; i < exposure.pageCount.toNumber(); ++i) {
-      others.push(...othersCounted[validatorIdString][i]);
+      const page = othersCounted[validatorIdString]?.[i];
+      if (page === undefined) {
+        throw new Error(
+          `Missing exposure page ${i} for validator ${validatorIdString} in era ${currentEra}`,
+        );
+      }
+      others.push(...page);
     }
 
     const eraValidatorInfo = new EraValidatorInfo(

--- a/src/mappings/NewEra.ts
+++ b/src/mappings/NewEra.ts
@@ -1,10 +1,10 @@
 import { SubstrateEvent } from "@subql/types";
-import { eventId } from "./common";
 import { EraValidatorInfo } from "../types/models/EraValidatorInfo";
 import { IndividualExposure } from "../types";
 import {
   SpStakingPagedExposureMetadata,
   SpStakingExposurePage,
+  PalletStakingActiveEraInfo,
 } from "@polkadot/types/lookup";
 import { Option } from "@polkadot/types";
 import { INumber } from "@polkadot/types-codec/types/interfaces";
@@ -16,23 +16,35 @@ export async function handleStakersElected(
   await handleNewEra(event);
 }
 
-// Asset Hub (staking-async): by the time EraPaid is emitted, currentEra already
-// points to the next planned era whose exposures are not on-chain yet, so the
-// snapshot is taken on the last page (index 0) of PagedElectionProceeded instead —
-// at that point the exposures for currentEra are fully written.
-export async function handlePagedElectionProceeded(
-  event: SubstrateEvent,
-): Promise<void> {
-  const pageIndex = event.event.data[0].toString();
-  if (pageIndex !== "0") {
+// Asset Hub (staking-async). How the chain rotates eras (Rotator/EraElectionPlanner in pallet-staking-async):
+// https://github.com/paritytech/polkadot-sdk/blob/470d1ad2a82c95c28c825412cb636aed4f54b83e/substrate/frame/staking-async/src/session_rotation.rs
+//
+// 1. `plan_new_era` (#L1018) bumps currentEra mid-era (planning deadline), so at any rotation
+//    currentEra already points to the NEXT planned era with no exposures in state.
+// 2. The multi-block election pulls pages msp..0; exposures are stored per page only
+//    on the Ok path of `do_elect_paged` (#L1178). `PagedElectionProceeded` is emitted per elect()
+//    attempt: newer runtimes skip page 0 on the success path and emit the full failed
+//    range with `result: Err`, so election events are NOT a reliable trigger.
+// 3. The validator set is sent to the relay chain only after the last election page,
+//    and only then the era can be activated: `Rotator::start_era` emits EraPaid (in both
+//    legacy and DAP end-era paths) and increments activeEra (`start_era`, #L860).
+//
+// Therefore at the EraPaid block exposures(activeEra) are guaranteed complete - an era
+// cannot start without its full validator set. Snapshot activeEra here.
+// getByEra guards against double-writes (backfill, reindex).
+export async function handleAHEraPaid(event: SubstrateEvent): Promise<void> {
+  const activeEra = (
+    (await api.query.staking.activeEra()) as Option<PalletStakingActiveEraInfo>
+  )
+    .unwrap()
+    .index.toNumber();
+
+  const existing = await EraValidatorInfo.getByEra(activeEra);
+  if (existing !== undefined && existing.length > 0) {
     return;
   }
 
-  const currentEra = ((await api.query.staking.currentEra()) as Option<INumber>)
-    .unwrap()
-    .toNumber();
-
-  await processEraStakersPaged(event, currentEra);
+  await processEraStakersPaged(activeEra);
 }
 
 export async function handleNewEra(event: SubstrateEvent): Promise<void> {
@@ -41,16 +53,13 @@ export async function handleNewEra(event: SubstrateEvent): Promise<void> {
     .toNumber();
 
   if (api.query.staking.erasStakersOverview) {
-    await processEraStakersPaged(event, currentEra);
+    await processEraStakersPaged(currentEra);
   } else {
-    await processEraStakersClipped(event, currentEra);
+    await processEraStakersClipped(currentEra);
   }
 }
 
-async function processEraStakersClipped(
-  event: SubstrateEvent,
-  currentEra: number,
-): Promise<void> {
+async function processEraStakersClipped(currentEra: number): Promise<void> {
   const exposures =
     await api.query.staking.erasStakersClipped.entries(currentEra);
 
@@ -59,7 +68,7 @@ async function processEraStakersClipped(
     let validatorIdString = validatorId.toString();
     const exp = exposure as unknown as Exposure;
     const eraValidatorInfo = new EraValidatorInfo(
-      eventId(event) + validatorIdString,
+      `${currentEra}-${validatorIdString}`,
       validatorIdString,
       currentEra,
       exp.total.toBigInt(),
@@ -75,10 +84,7 @@ async function processEraStakersClipped(
   }
 }
 
-async function processEraStakersPaged(
-  event: SubstrateEvent,
-  currentEra: number,
-): Promise<void> {
+async function processEraStakersPaged(currentEra: number): Promise<void> {
   const overview =
     await api.query.staking.erasStakersOverview.entries(currentEra);
   const pages = await api.query.staking.erasStakersPaged.entries(currentEra);
@@ -124,7 +130,7 @@ async function processEraStakersPaged(
     }
 
     const eraValidatorInfo = new EraValidatorInfo(
-      eventId(event) + validatorIdString,
+      `${currentEra}-${validatorIdString}`,
       validatorIdString,
       currentEra,
       exposure.total.toBigInt(),

--- a/src/mappings/NewEra.ts
+++ b/src/mappings/NewEra.ts
@@ -16,6 +16,25 @@ export async function handleStakersElected(
   await handleNewEra(event);
 }
 
+// Asset Hub (staking-async): by the time EraPaid is emitted, currentEra already
+// points to the next planned era whose exposures are not on-chain yet, so the
+// snapshot is taken on the last page (index 0) of PagedElectionProceeded instead —
+// at that point the exposures for currentEra are fully written.
+export async function handlePagedElectionProceeded(
+  event: SubstrateEvent,
+): Promise<void> {
+  const pageIndex = event.event.data[0].toString();
+  if (pageIndex !== "0") {
+    return;
+  }
+
+  const currentEra = ((await api.query.staking.currentEra()) as Option<INumber>)
+    .unwrap()
+    .toNumber();
+
+  await processEraStakersPaged(event, currentEra);
+}
+
 export async function handleNewEra(event: SubstrateEvent): Promise<void> {
   const currentEra = ((await api.query.staking.currentEra()) as Option<INumber>)
     .unwrap()

--- a/statemine.yaml
+++ b/statemine.yaml
@@ -68,16 +68,11 @@ dataSources:
           filter:
             module: staking
             method: Slashed
-        - handler: handleNewEra
+        - handler: handlePagedElectionProceeded
           kind: substrate/EventHandler
           filter:
             module: staking
-            method: StakingElection
-        - handler: handleStakersElected
-          kind: substrate/EventHandler
-          filter:
-            module: staking
-            method: EraPaid
+            method: PagedElectionProceeded
         - handler: handlePoolBondedSlash
           kind: substrate/EventHandler
           filter:

--- a/statemine.yaml
+++ b/statemine.yaml
@@ -68,11 +68,11 @@ dataSources:
           filter:
             module: staking
             method: Slashed
-        - handler: handlePagedElectionProceeded
+        - handler: handleAHEraPaid
           kind: substrate/EventHandler
           filter:
             module: staking
-            method: PagedElectionProceeded
+            method: EraPaid
         - handler: handlePoolBondedSlash
           kind: substrate/EventHandler
           filter:

--- a/statemint.yaml
+++ b/statemint.yaml
@@ -68,16 +68,11 @@ dataSources:
           filter:
             module: staking
             method: Slashed
-        - handler: handleNewEra
+        - handler: handlePagedElectionProceeded
           kind: substrate/EventHandler
           filter:
             module: staking
-            method: StakingElection
-        - handler: handleStakersElected
-          kind: substrate/EventHandler
-          filter:
-            module: staking
-            method: EraPaid
+            method: PagedElectionProceeded
         - handler: handlePoolBondedSlash
           kind: substrate/EventHandler
           filter:

--- a/statemint.yaml
+++ b/statemint.yaml
@@ -68,11 +68,11 @@ dataSources:
           filter:
             module: staking
             method: Slashed
-        - handler: handlePagedElectionProceeded
+        - handler: handleAHEraPaid
           kind: substrate/EventHandler
           filter:
             module: staking
-            method: PagedElectionProceeded
+            method: EraPaid
         - handler: handlePoolBondedSlash
           kind: substrate/EventHandler
           filter:

--- a/tests/newEra.test.ts
+++ b/tests/newEra.test.ts
@@ -1,5 +1,5 @@
 import { EraValidatorInfo } from "../src/types";
-import { handlePagedElectionProceeded } from "../src/mappings/NewEra";
+import { handleAHEraPaid } from "../src/mappings/NewEra";
 import {
   SubstrateTestEventBuilder,
   mockOption,
@@ -7,7 +7,8 @@ import {
   mockAddress,
 } from "./utils/mockFunctions";
 
-const CURRENT_ERA = 2228;
+const ACTIVE_ERA = 2227;
+const PLANNED_ERA = 2228;
 
 const VALIDATOR_A = "14LzEeAqYAgVvbxqzdVQGL8zPQFe1o5zGRSbCZDwtCd2AZgA";
 const VALIDATOR_B = "15wD8upZxRZijKkF7JZDdaaFXuRZJhFyYpFQC5j6FaZL5PzA";
@@ -17,7 +18,7 @@ const NOMINATOR_3 = "13FNi4e4EJRpweeTZiUBA4BvjeMKZBxf67h5cyzxxRvHcBMk";
 
 function mockOverviewEntry(validator: string, pageCount: number) {
   return [
-    { args: [mockNumber(CURRENT_ERA), mockAddress(validator)] },
+    { args: [mockNumber(ACTIVE_ERA), mockAddress(validator)] },
     mockOption({
       total: mockNumber(3000),
       own: mockNumber(1000),
@@ -29,7 +30,7 @@ function mockOverviewEntry(validator: string, pageCount: number) {
 function mockPageEntry(validator: string, page: number, others: string[]) {
   return [
     {
-      args: [mockNumber(CURRENT_ERA), mockAddress(validator), mockNumber(page)],
+      args: [mockNumber(ACTIVE_ERA), mockAddress(validator), mockNumber(page)],
     },
     mockOption({
       others: others.map((who) => {
@@ -39,35 +40,45 @@ function mockPageEntry(validator: string, page: number, others: string[]) {
   ];
 }
 
+// At the EraPaid (rotation) block, exposures exist only for the era that just
+// became active; the planned era (currentEra) is not elected yet.
 const mockAPI = {
   query: {
     staking: {
-      currentEra: async () => mockOption(mockNumber(CURRENT_ERA)),
+      activeEra: async () =>
+        mockOption({ index: mockNumber(ACTIVE_ERA), start: mockOption(0) }),
+      currentEra: async () => mockOption(mockNumber(PLANNED_ERA)),
       erasStakersOverview: {
-        entries: async (_era: number) => [
-          mockOverviewEntry(VALIDATOR_A, 2),
-          mockOverviewEntry(VALIDATOR_B, 1),
-        ],
+        entries: async (era: number) =>
+          era === ACTIVE_ERA
+            ? [
+                mockOverviewEntry(VALIDATOR_A, 2),
+                mockOverviewEntry(VALIDATOR_B, 1),
+              ]
+            : [],
       },
       erasStakersPaged: {
-        entries: async (_era: number) => [
-          mockPageEntry(VALIDATOR_A, 0, [NOMINATOR_1]),
-          mockPageEntry(VALIDATOR_A, 1, [NOMINATOR_2]),
-          mockPageEntry(VALIDATOR_B, 0, [NOMINATOR_3]),
-        ],
+        entries: async (era: number) =>
+          era === ACTIVE_ERA
+            ? [
+                mockPageEntry(VALIDATOR_A, 0, [NOMINATOR_1]),
+                mockPageEntry(VALIDATOR_A, 1, [NOMINATOR_2]),
+                mockPageEntry(VALIDATOR_B, 0, [NOMINATOR_3]),
+              ]
+            : [],
       },
     },
   },
 };
 
-function pagedElectionEvent(pageIndex: number) {
+function eraPaidEvent() {
   return new SubstrateTestEventBuilder()
     .withBlock(new Date(), 18040436)
-    .withEvent([mockNumber(pageIndex), mockOption({})], 7)
+    .withEvent([mockNumber(ACTIVE_ERA - 1), mockNumber(1), mockNumber(1)], 7)
     .build();
 }
 
-describe("handlePagedElectionProceeded", () => {
+describe("handleAHEraPaid", () => {
   let savedInfos: EraValidatorInfo[] = [];
 
   beforeAll(() => {
@@ -90,21 +101,17 @@ describe("handlePagedElectionProceeded", () => {
     savedInfos = [];
   });
 
-  it("skips pages other than the last one (page index != 0)", async () => {
-    await handlePagedElectionProceeded(pagedElectionEvent(3));
+  it("snapshots the active era with merged pages and deterministic ids", async () => {
+    jest.spyOn(EraValidatorInfo, "getByEra").mockResolvedValue([]);
 
-    expect(savedInfos).toHaveLength(0);
-  });
-
-  it("saves era validator infos with merged pages on page index 0", async () => {
-    await handlePagedElectionProceeded(pagedElectionEvent(0));
+    await handleAHEraPaid(eraPaidEvent());
 
     expect(savedInfos).toHaveLength(2);
 
     const infoA = savedInfos.find((info) => info.address === VALIDATOR_A);
     expect(infoA).toBeDefined();
-    expect(infoA.id).toBe(`18040436-7${VALIDATOR_A}`);
-    expect(infoA.era).toBe(CURRENT_ERA);
+    expect(infoA.id).toBe(`${ACTIVE_ERA}-${VALIDATOR_A}`);
+    expect(infoA.era).toBe(ACTIVE_ERA);
     expect(infoA.total).toBe(BigInt(3000));
     expect(infoA.own).toBe(BigInt(1000));
     expect(infoA.others.map((other) => other.who)).toEqual([
@@ -114,7 +121,19 @@ describe("handlePagedElectionProceeded", () => {
 
     const infoB = savedInfos.find((info) => info.address === VALIDATOR_B);
     expect(infoB).toBeDefined();
-    expect(infoB.era).toBe(CURRENT_ERA);
+    expect(infoB.id).toBe(`${ACTIVE_ERA}-${VALIDATOR_B}`);
     expect(infoB.others.map((other) => other.who)).toEqual([NOMINATOR_3]);
+  });
+
+  it("skips eras that are already indexed (backfill or earlier run)", async () => {
+    jest
+      .spyOn(EraValidatorInfo, "getByEra")
+      .mockResolvedValue([
+        { id: `${ACTIVE_ERA}-backfill-x` } as EraValidatorInfo,
+      ]);
+
+    await handleAHEraPaid(eraPaidEvent());
+
+    expect(savedInfos).toHaveLength(0);
   });
 });

--- a/tests/newEra.test.ts
+++ b/tests/newEra.test.ts
@@ -1,0 +1,120 @@
+import { EraValidatorInfo } from "../src/types";
+import { handlePagedElectionProceeded } from "../src/mappings/NewEra";
+import {
+  SubstrateTestEventBuilder,
+  mockOption,
+  mockNumber,
+  mockAddress,
+} from "./utils/mockFunctions";
+
+const CURRENT_ERA = 2228;
+
+const VALIDATOR_A = "14LzEeAqYAgVvbxqzdVQGL8zPQFe1o5zGRSbCZDwtCd2AZgA";
+const VALIDATOR_B = "15wD8upZxRZijKkF7JZDdaaFXuRZJhFyYpFQC5j6FaZL5PzA";
+const NOMINATOR_1 = "136fZX6JHbywxoMXZiTY23eGGGkb3HrW7UHWZvZ5JGLzSGNF";
+const NOMINATOR_2 = "14UpRGUeAfsSZHFN63t4ojJrLNupPApUiLgovXtm7ZiAHUDA";
+const NOMINATOR_3 = "13FNi4e4EJRpweeTZiUBA4BvjeMKZBxf67h5cyzxxRvHcBMk";
+
+function mockOverviewEntry(validator: string, pageCount: number) {
+  return [
+    { args: [mockNumber(CURRENT_ERA), mockAddress(validator)] },
+    mockOption({
+      total: mockNumber(3000),
+      own: mockNumber(1000),
+      pageCount: mockNumber(pageCount),
+    }),
+  ];
+}
+
+function mockPageEntry(validator: string, page: number, others: string[]) {
+  return [
+    {
+      args: [mockNumber(CURRENT_ERA), mockAddress(validator), mockNumber(page)],
+    },
+    mockOption({
+      others: others.map((who) => {
+        return { who: mockAddress(who), value: mockNumber(1000) };
+      }),
+    }),
+  ];
+}
+
+const mockAPI = {
+  query: {
+    staking: {
+      currentEra: async () => mockOption(mockNumber(CURRENT_ERA)),
+      erasStakersOverview: {
+        entries: async (_era: number) => [
+          mockOverviewEntry(VALIDATOR_A, 2),
+          mockOverviewEntry(VALIDATOR_B, 1),
+        ],
+      },
+      erasStakersPaged: {
+        entries: async (_era: number) => [
+          mockPageEntry(VALIDATOR_A, 0, [NOMINATOR_1]),
+          mockPageEntry(VALIDATOR_A, 1, [NOMINATOR_2]),
+          mockPageEntry(VALIDATOR_B, 0, [NOMINATOR_3]),
+        ],
+      },
+    },
+  },
+};
+
+function pagedElectionEvent(pageIndex: number) {
+  return new SubstrateTestEventBuilder()
+    .withBlock(new Date(), 18040436)
+    .withEvent([mockNumber(pageIndex), mockOption({})], 7)
+    .build();
+}
+
+describe("handlePagedElectionProceeded", () => {
+  let savedInfos: EraValidatorInfo[] = [];
+
+  beforeAll(() => {
+    (global as any).api = mockAPI;
+    (global as any).logger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+
+    jest.spyOn(EraValidatorInfo.prototype, "save").mockImplementation(function (
+      this: EraValidatorInfo,
+    ) {
+      savedInfos.push(this);
+      return Promise.resolve();
+    });
+  });
+
+  beforeEach(() => {
+    savedInfos = [];
+  });
+
+  it("skips pages other than the last one (page index != 0)", async () => {
+    await handlePagedElectionProceeded(pagedElectionEvent(3));
+
+    expect(savedInfos).toHaveLength(0);
+  });
+
+  it("saves era validator infos with merged pages on page index 0", async () => {
+    await handlePagedElectionProceeded(pagedElectionEvent(0));
+
+    expect(savedInfos).toHaveLength(2);
+
+    const infoA = savedInfos.find((info) => info.address === VALIDATOR_A);
+    expect(infoA).toBeDefined();
+    expect(infoA.id).toBe(`18040436-7${VALIDATOR_A}`);
+    expect(infoA.era).toBe(CURRENT_ERA);
+    expect(infoA.total).toBe(BigInt(3000));
+    expect(infoA.own).toBe(BigInt(1000));
+    expect(infoA.others.map((other) => other.who)).toEqual([
+      NOMINATOR_1,
+      NOMINATOR_2,
+    ]);
+
+    const infoB = savedInfos.find((info) => info.address === VALIDATOR_B);
+    expect(infoB).toBeDefined();
+    expect(infoB.era).toBe(CURRENT_ERA);
+    expect(infoB.others.map((other) => other.who)).toEqual([NOMINATOR_3]);
+  });
+});

--- a/tests/newEra.test.ts
+++ b/tests/newEra.test.ts
@@ -102,7 +102,7 @@ describe("handleAHEraPaid", () => {
   });
 
   it("snapshots the active era with merged pages and deterministic ids", async () => {
-    jest.spyOn(EraValidatorInfo, "getByEra").mockResolvedValue([]);
+    jest.spyOn(EraValidatorInfo, "getByFields").mockResolvedValue([]);
 
     await handleAHEraPaid(eraPaidEvent());
 
@@ -127,7 +127,7 @@ describe("handleAHEraPaid", () => {
 
   it("skips eras that are already indexed (backfill or earlier run)", async () => {
     jest
-      .spyOn(EraValidatorInfo, "getByEra")
+      .spyOn(EraValidatorInfo, "getByFields")
       .mockResolvedValue([
         { id: `${ACTIVE_ERA}-backfill-x` } as EraValidatorInfo,
       ]);

--- a/tests/reward.test.ts
+++ b/tests/reward.test.ts
@@ -14,6 +14,7 @@ import {
   mockOption,
   mockNumber,
   mockAddress,
+  mockBTreeMap,
 } from "./utils/mockFunctions";
 import { RewardType } from "../src/types";
 
@@ -47,7 +48,7 @@ const mockSubPoolsStorage = {
       points: mockNumber(1000),
       balance: mockNumber(1000),
     },
-    withEra: {
+    withEra: mockBTreeMap({
       4904: {
         points: mockNumber(2000),
         balance: mockNumber(2000),
@@ -56,55 +57,55 @@ const mockSubPoolsStorage = {
         points: mockNumber(0),
         balance: mockNumber(0),
       },
-    },
+    }),
   }),
 };
 
 const mockPoolMembers = [
   [
-    [mockAddress("12JFwUszJsgVUr5YW3QcheYmDZHNYHiPELbuJx3rm6guhrse")],
+    { args: [mockAddress("12JFwUszJsgVUr5YW3QcheYmDZHNYHiPELbuJx3rm6guhrse")] },
     mockOption({
       isSome: true,
       poolId: mockNumber(16),
       points: mockNumber(100),
       lastRecordedRewardCounter: undefined,
-      unbondingEras: {},
+      unbondingEras: mockBTreeMap({}),
     }),
   ],
   [
-    [mockAddress("16XzkhKCZqFA4yYd2nfrNk8GZBhq8xkdAQZe3T8tUWxanWWj")],
+    { args: [mockAddress("16XzkhKCZqFA4yYd2nfrNk8GZBhq8xkdAQZe3T8tUWxanWWj")] },
     mockOption({
       isSome: true,
       poolId: mockNumber(42),
       points: mockNumber(100),
       lastRecordedRewardCounter: undefined,
-      unbondingEras: {
+      unbondingEras: mockBTreeMap({
         4904: mockNumber(10),
-      },
+      }),
     }),
   ],
   [
-    [mockAddress("128uKFo94ewG8BrRXyqVQFDj8753XNfgsDUp9DSGdh8erKwS")],
+    { args: [mockAddress("128uKFo94ewG8BrRXyqVQFDj8753XNfgsDUp9DSGdh8erKwS")] },
     mockOption({
       isSome: true,
       poolId: mockNumber(42),
       points: mockNumber(50),
       lastRecordedRewardCounter: undefined,
-      unbondingEras: {
+      unbondingEras: mockBTreeMap({
         5426: mockNumber(5),
-      },
+      }),
     }),
   ],
   [
-    [mockAddress("13au37C1nZtMjvv2uPHRvamYdgAVxffTWJoCZXo2sw1NeysP")],
+    { args: [mockAddress("13au37C1nZtMjvv2uPHRvamYdgAVxffTWJoCZXo2sw1NeysP")] },
     mockOption({
       isSome: true,
       poolId: mockNumber(42),
       points: mockNumber(25),
       lastRecordedRewardCounter: undefined,
-      unbondingEras: {
+      unbondingEras: mockBTreeMap({
         1: mockNumber(1234),
-      },
+      }),
     }),
   ],
 ];

--- a/tests/utils/mockFunctions.ts
+++ b/tests/utils/mockFunctions.ts
@@ -74,7 +74,8 @@ export class SubstrateTestEventBuilder<T extends AnyTuple = AnyTuple> {
     amount,
     idx = 0,
   ): SubstrateEvent<T> {
-    return this.withBlock().withEvent([era, poolId, amount], idx).build();
+    // on-chain event order: UnbondingPoolSlashed(pool_id, era, balance)
+    return this.withBlock().withEvent([poolId, era, amount], idx).build();
   }
 }
 
@@ -107,5 +108,18 @@ export function mockNumber(number: number): unknown {
     toString: jest.fn().mockReturnValue(number.toString()),
     toNumber: jest.fn().mockReturnValue(number),
     toBigInt: jest.fn().mockReturnValue(BigInt(number)),
+  };
+}
+
+// Mimics a BTreeMap codec: get() accepts a plain number or a numeric codec
+export function mockBTreeMap(entries: Record<number, unknown>): unknown {
+  return {
+    get: (key: unknown) => {
+      const numericKey =
+        typeof key === "number"
+          ? key
+          : (key as { toNumber(): number }).toNumber();
+      return entries[numericKey];
+    },
   };
 }

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "isolatedModules": true,
+    "types": ["jest", "node"],
+    "noImplicitAny": false
+  }
+}

--- a/westmint.yaml
+++ b/westmint.yaml
@@ -67,11 +67,11 @@ dataSources:
           filter:
             module: staking
             method: Slashed
-        - handler: handlePagedElectionProceeded
+        - handler: handleAHEraPaid
           kind: substrate/EventHandler
           filter:
             module: staking
-            method: PagedElectionProceeded
+            method: EraPaid
         - handler: handlePoolBondedSlash
           kind: substrate/EventHandler
           filter:

--- a/westmint.yaml
+++ b/westmint.yaml
@@ -67,16 +67,11 @@ dataSources:
           filter:
             module: staking
             method: Slashed
-        - handler: handleNewEra
+        - handler: handlePagedElectionProceeded
           kind: substrate/EventHandler
           filter:
             module: staking
-            method: StakingElection
-        - handler: handleStakersElected
-          kind: substrate/EventHandler
-          filter:
-            module: staking
-            method: StakersElected
+            method: PagedElectionProceeded
         - handler: handlePoolBondedSlash
           kind: substrate/EventHandler
           filter:


### PR DESCRIPTION
## Problem

Nominator pending payouts are empty in both Android and iOS apps: the `eraValidatorInfos` query returns nothing for any nominator (novasamatech/nova-wallet-android#2290).

The AH projects snapshot era exposures in `handleNewEra`/`handleStakersElected`, triggered by `staking.EraPaid` / `StakingElection`, reading `erasStakersOverview`/`erasStakersPaged` for `currentEra`. After the staking-async runtime upgrade on Asset Hub (late Jan 2026), `currentEra` at the `EraPaid` block already points to the **next planned era**, whose exposures are not on-chain yet — the election writes them later in the era, page by page. `.entries(currentEra)` returns `[]` and the handler silently saves nothing.

Verified on-chain at today's era rotation block 18040436 (Polkadot AH): `currentEra` = 2228, `erasStakersOverview(2228)` = 0 keys, `erasStakersOverview(2227)` = 600 keys.

As a result, EraValidatorInfo is frozen at era **2065** on Polkadot AH (chain is at 2228) and **8993** on Kusama AH (chain at 9767), while the wallet queries the last-84-eras payout window — always empty since ~April 2026.

## Fix

Same approach as novasamatech/subquery-staking#98: trigger the snapshot on `staking.PagedElectionProceeded` and process only the last page (index 0) — at that point exposures for `currentEra` are fully in state.

- `statemint.yaml`, `statemine.yaml`, `westmint.yaml`: replace the `StakingElection`/`EraPaid`(/`StakersElected`) era handlers with a single `PagedElectionProceeded` handler
- `src/mappings/NewEra.ts`: add `handlePagedElectionProceeded` reusing the existing paged snapshot logic
- relay-chain projects are untouched (`handleNewEra`/`handleStakersElected` remain for them)

## Backfill

The fix only covers new eras. `scripts/backfill_era_validator_infos.js` restores the missing part of the payout window from current on-chain state (exposures for the last `historyDepth` = 84 eras are still in state, no reindex needed). It generates idempotent SQL (`ON CONFLICT (id) DO NOTHING`) to apply with `psql`:

```
node scripts/backfill_era_validator_infos.js --ws wss://asset-hub-polkadot-rpc.n.dwellir.com --out polkadot-ah.sql
node scripts/backfill_era_validator_infos.js --ws wss://kusama-asset-hub-rpc.polkadot.io --out kusama-ah.sql
```
