### PR TITLE
CI: run jest on PRs and fix stale pool reward test mocks

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,5 +16,7 @@ jobs:
         run: yarn install
       - name: Codegen
         run: yarn codegen
+      - name: Test
+        run: yarn test
       - name: Build
         run: yarn build

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "./node_modules/.bin/subql build",
     "start:docker": "docker-compose pull && docker-compose up --remove-orphans",
     "codegen": "./node_modules/.bin/subql codegen",
+    "test": "jest",
     "validate": "./node_modules/.bin/subql validate",
     "prepare": "husky install",
     "local-publish": "cd ./scripts && ./local-publish.sh"

--- a/tests/reward.test.ts
+++ b/tests/reward.test.ts
@@ -14,6 +14,7 @@ import {
   mockOption,
   mockNumber,
   mockAddress,
+  mockBTreeMap,
 } from "./utils/mockFunctions";
 import { RewardType } from "../src/types";
 
@@ -47,7 +48,7 @@ const mockSubPoolsStorage = {
       points: mockNumber(1000),
       balance: mockNumber(1000),
     },
-    withEra: {
+    withEra: mockBTreeMap({
       4904: {
         points: mockNumber(2000),
         balance: mockNumber(2000),
@@ -56,55 +57,55 @@ const mockSubPoolsStorage = {
         points: mockNumber(0),
         balance: mockNumber(0),
       },
-    },
+    }),
   }),
 };
 
 const mockPoolMembers = [
   [
-    [mockAddress("12JFwUszJsgVUr5YW3QcheYmDZHNYHiPELbuJx3rm6guhrse")],
+    { args: [mockAddress("12JFwUszJsgVUr5YW3QcheYmDZHNYHiPELbuJx3rm6guhrse")] },
     mockOption({
       isSome: true,
       poolId: mockNumber(16),
       points: mockNumber(100),
       lastRecordedRewardCounter: undefined,
-      unbondingEras: {},
+      unbondingEras: mockBTreeMap({}),
     }),
   ],
   [
-    [mockAddress("16XzkhKCZqFA4yYd2nfrNk8GZBhq8xkdAQZe3T8tUWxanWWj")],
+    { args: [mockAddress("16XzkhKCZqFA4yYd2nfrNk8GZBhq8xkdAQZe3T8tUWxanWWj")] },
     mockOption({
       isSome: true,
       poolId: mockNumber(42),
       points: mockNumber(100),
       lastRecordedRewardCounter: undefined,
-      unbondingEras: {
+      unbondingEras: mockBTreeMap({
         4904: mockNumber(10),
-      },
+      }),
     }),
   ],
   [
-    [mockAddress("128uKFo94ewG8BrRXyqVQFDj8753XNfgsDUp9DSGdh8erKwS")],
+    { args: [mockAddress("128uKFo94ewG8BrRXyqVQFDj8753XNfgsDUp9DSGdh8erKwS")] },
     mockOption({
       isSome: true,
       poolId: mockNumber(42),
       points: mockNumber(50),
       lastRecordedRewardCounter: undefined,
-      unbondingEras: {
+      unbondingEras: mockBTreeMap({
         5426: mockNumber(5),
-      },
+      }),
     }),
   ],
   [
-    [mockAddress("13au37C1nZtMjvv2uPHRvamYdgAVxffTWJoCZXo2sw1NeysP")],
+    { args: [mockAddress("13au37C1nZtMjvv2uPHRvamYdgAVxffTWJoCZXo2sw1NeysP")] },
     mockOption({
       isSome: true,
       poolId: mockNumber(42),
       points: mockNumber(25),
       lastRecordedRewardCounter: undefined,
-      unbondingEras: {
+      unbondingEras: mockBTreeMap({
         1: mockNumber(1234),
-      },
+      }),
     }),
   ],
 ];

--- a/tests/utils/mockFunctions.ts
+++ b/tests/utils/mockFunctions.ts
@@ -74,7 +74,8 @@ export class SubstrateTestEventBuilder<T extends AnyTuple = AnyTuple> {
     amount,
     idx = 0,
   ): SubstrateEvent<T> {
-    return this.withBlock().withEvent([era, poolId, amount], idx).build();
+    // on-chain event order: UnbondingPoolSlashed(pool_id, era, balance)
+    return this.withBlock().withEvent([poolId, era, amount], idx).build();
   }
 }
 
@@ -107,5 +108,18 @@ export function mockNumber(number: number): unknown {
     toString: jest.fn().mockReturnValue(number.toString()),
     toNumber: jest.fn().mockReturnValue(number),
     toBigInt: jest.fn().mockReturnValue(BigInt(number)),
+  };
+}
+
+// Mimics a BTreeMap codec: get() accepts a plain number or a numeric codec
+export function mockBTreeMap(entries: Record<number, unknown>): unknown {
+  return {
+    get: (key: unknown) => {
+      const numericKey =
+        typeof key === "number"
+          ? key
+          : (key as { toNumber(): number }).toNumber();
+      return entries[numericKey];
+    },
   };
 }


### PR DESCRIPTION
Follow-up to #336 (based on its branch).

## Problem

The jest suite is not wired into CI (`pr.yml` only runs install/codegen/build), so `tests/reward.test.ts` silently rotted: before #336 it did not even compile, and after fixing the jest config 5 of 6 tests failed at runtime because the mocks predate the current handler code.

## Changes

- **CI**: add a `Test` step (`yarn test`) to the PR workflow between codegen and build, plus a `test` script in package.json
- **Mock fixes** (production code untouched):
  - `poolMembers.entries()` keys are StorageKey-like — `{args: [accountId]}` instead of a bare array (`Cache.ts` reads `accountId.args[0]`)
  - `unbondingEras` and `subPools.withEra` are BTreeMap codecs — added a `mockBTreeMap` helper with `.get()` accepting a plain number or numeric codec (`PoolRewards.ts` calls `.get(era)`)
  - `buildEventForUnbondingPoolSlash` emitted event data as `[era, poolId, balance]`, but the on-chain `nominationPools.UnbondingPoolSlashed` event (and the handler destructuring) is `(pool_id, era, balance)`

## Verification

`yarn test`: 2 suites, 8/8 tests pass (5 previously failing reward tests + caching test + the 2 new era snapshot tests from #336).
