### PR TITLE
Fix: snapshot activeEra on EraPaid — election page-0 events are gone on new runtimes

### DIFF
--- a/src/mappings/NewEra.ts
+++ b/src/mappings/NewEra.ts
@@ -16,18 +16,18 @@ export async function handleStakersElected(
   await handleNewEra(event);
 }
 
-// Asset Hub (staking-async). How the chain rotates eras (see Rotator/EraElectionPlanner in
-// https://github.com/paritytech/polkadot-sdk/blob/master/substrate/frame/staking-async/src/session_rotation.rs):
+// Asset Hub (staking-async). How the chain rotates eras (Rotator/EraElectionPlanner in pallet-staking-async):
+// https://github.com/paritytech/polkadot-sdk/blob/470d1ad2a82c95c28c825412cb636aed4f54b83e/substrate/frame/staking-async/src/session_rotation.rs
 //
-// 1. `plan_new_era` bumps currentEra mid-era (planning deadline), so at any rotation
+// 1. `plan_new_era` (#L1018) bumps currentEra mid-era (planning deadline), so at any rotation
 //    currentEra already points to the NEXT planned era with no exposures in state.
 // 2. The multi-block election pulls pages msp..0; exposures are stored per page only
-//    on the Ok path of `do_elect_paged`. `PagedElectionProceeded` is emitted per elect()
+//    on the Ok path of `do_elect_paged` (#L1178). `PagedElectionProceeded` is emitted per elect()
 //    attempt: newer runtimes skip page 0 on the success path and emit the full failed
 //    range with `result: Err`, so election events are NOT a reliable trigger.
 // 3. The validator set is sent to the relay chain only after the last election page,
 //    and only then the era can be activated: `Rotator::start_era` emits EraPaid (in both
-//    legacy and DAP end-era paths) and increments activeEra.
+//    legacy and DAP end-era paths) and increments activeEra (`start_era`, #L860).
 //
 // Therefore at the EraPaid block exposures(activeEra) are guaranteed complete - an era
 // cannot start without its full validator set. Snapshot activeEra here.

--- a/src/mappings/NewEra.ts
+++ b/src/mappings/NewEra.ts
@@ -1,10 +1,10 @@
 import { SubstrateEvent } from "@subql/types";
-import { eventId } from "./common";
 import { EraValidatorInfo } from "../types/models/EraValidatorInfo";
 import { IndividualExposure } from "../types";
 import {
   SpStakingPagedExposureMetadata,
   SpStakingExposurePage,
+  PalletStakingActiveEraInfo,
 } from "@polkadot/types/lookup";
 import { Option } from "@polkadot/types";
 import { INumber } from "@polkadot/types-codec/types/interfaces";
@@ -16,23 +16,25 @@ export async function handleStakersElected(
   await handleNewEra(event);
 }
 
-// Asset Hub (staking-async): by the time EraPaid is emitted, currentEra already
-// points to the next planned era whose exposures are not on-chain yet, so the
-// snapshot is taken on the last page (index 0) of PagedElectionProceeded instead —
-// at that point the exposures for currentEra are fully written.
-export async function handlePagedElectionProceeded(
-  event: SubstrateEvent,
-): Promise<void> {
-  const pageIndex = event.event.data[0].toString();
-  if (pageIndex !== "0") {
+// Asset Hub (staking-async): currentEra at the EraPaid block already points to
+// the next planned era whose exposures are not on-chain yet, and election events
+// are not reliable either (recent runtimes stopped emitting PagedElectionProceeded
+// for every page on the success path). The era that just became active is the
+// invariant: it cannot start without its full validator set, so snapshot activeEra
+// at the rotation block. getByEra guards against double-writes (backfill, reindex).
+export async function handleAHEraPaid(event: SubstrateEvent): Promise<void> {
+  const activeEra = (
+    (await api.query.staking.activeEra()) as Option<PalletStakingActiveEraInfo>
+  )
+    .unwrap()
+    .index.toNumber();
+
+  const existing = await EraValidatorInfo.getByEra(activeEra);
+  if (existing !== undefined && existing.length > 0) {
     return;
   }
 
-  const currentEra = ((await api.query.staking.currentEra()) as Option<INumber>)
-    .unwrap()
-    .toNumber();
-
-  await processEraStakersPaged(event, currentEra);
+  await processEraStakersPaged(activeEra);
 }
 
 export async function handleNewEra(event: SubstrateEvent): Promise<void> {
@@ -41,16 +43,13 @@ export async function handleNewEra(event: SubstrateEvent): Promise<void> {
     .toNumber();
 
   if (api.query.staking.erasStakersOverview) {
-    await processEraStakersPaged(event, currentEra);
+    await processEraStakersPaged(currentEra);
   } else {
-    await processEraStakersClipped(event, currentEra);
+    await processEraStakersClipped(currentEra);
   }
 }
 
-async function processEraStakersClipped(
-  event: SubstrateEvent,
-  currentEra: number,
-): Promise<void> {
+async function processEraStakersClipped(currentEra: number): Promise<void> {
   const exposures =
     await api.query.staking.erasStakersClipped.entries(currentEra);
 
@@ -59,7 +58,7 @@ async function processEraStakersClipped(
     let validatorIdString = validatorId.toString();
     const exp = exposure as unknown as Exposure;
     const eraValidatorInfo = new EraValidatorInfo(
-      eventId(event) + validatorIdString,
+      `${currentEra}-${validatorIdString}`,
       validatorIdString,
       currentEra,
       exp.total.toBigInt(),
@@ -75,10 +74,7 @@ async function processEraStakersClipped(
   }
 }
 
-async function processEraStakersPaged(
-  event: SubstrateEvent,
-  currentEra: number,
-): Promise<void> {
+async function processEraStakersPaged(currentEra: number): Promise<void> {
   const overview =
     await api.query.staking.erasStakersOverview.entries(currentEra);
   const pages = await api.query.staking.erasStakersPaged.entries(currentEra);
@@ -124,7 +120,7 @@ async function processEraStakersPaged(
     }
 
     const eraValidatorInfo = new EraValidatorInfo(
-      eventId(event) + validatorIdString,
+      `${currentEra}-${validatorIdString}`,
       validatorIdString,
       currentEra,
       exposure.total.toBigInt(),

--- a/src/mappings/NewEra.ts
+++ b/src/mappings/NewEra.ts
@@ -16,12 +16,22 @@ export async function handleStakersElected(
   await handleNewEra(event);
 }
 
-// Asset Hub (staking-async): currentEra at the EraPaid block already points to
-// the next planned era whose exposures are not on-chain yet, and election events
-// are not reliable either (recent runtimes stopped emitting PagedElectionProceeded
-// for every page on the success path). The era that just became active is the
-// invariant: it cannot start without its full validator set, so snapshot activeEra
-// at the rotation block. getByEra guards against double-writes (backfill, reindex).
+// Asset Hub (staking-async). How the chain rotates eras (see Rotator/EraElectionPlanner in
+// https://github.com/paritytech/polkadot-sdk/blob/master/substrate/frame/staking-async/src/session_rotation.rs):
+//
+// 1. `plan_new_era` bumps currentEra mid-era (planning deadline), so at any rotation
+//    currentEra already points to the NEXT planned era with no exposures in state.
+// 2. The multi-block election pulls pages msp..0; exposures are stored per page only
+//    on the Ok path of `do_elect_paged`. `PagedElectionProceeded` is emitted per elect()
+//    attempt: newer runtimes skip page 0 on the success path and emit the full failed
+//    range with `result: Err`, so election events are NOT a reliable trigger.
+// 3. The validator set is sent to the relay chain only after the last election page,
+//    and only then the era can be activated: `Rotator::start_era` emits EraPaid (in both
+//    legacy and DAP end-era paths) and increments activeEra.
+//
+// Therefore at the EraPaid block exposures(activeEra) are guaranteed complete - an era
+// cannot start without its full validator set. Snapshot activeEra here.
+// getByEra guards against double-writes (backfill, reindex).
 export async function handleAHEraPaid(event: SubstrateEvent): Promise<void> {
   const activeEra = (
     (await api.query.staking.activeEra()) as Option<PalletStakingActiveEraInfo>

--- a/statemine.yaml
+++ b/statemine.yaml
@@ -68,11 +68,11 @@ dataSources:
           filter:
             module: staking
             method: Slashed
-        - handler: handlePagedElectionProceeded
+        - handler: handleAHEraPaid
           kind: substrate/EventHandler
           filter:
             module: staking
-            method: PagedElectionProceeded
+            method: EraPaid
         - handler: handlePoolBondedSlash
           kind: substrate/EventHandler
           filter:

--- a/statemint.yaml
+++ b/statemint.yaml
@@ -68,11 +68,11 @@ dataSources:
           filter:
             module: staking
             method: Slashed
-        - handler: handlePagedElectionProceeded
+        - handler: handleAHEraPaid
           kind: substrate/EventHandler
           filter:
             module: staking
-            method: PagedElectionProceeded
+            method: EraPaid
         - handler: handlePoolBondedSlash
           kind: substrate/EventHandler
           filter:

--- a/tests/newEra.test.ts
+++ b/tests/newEra.test.ts
@@ -1,5 +1,5 @@
 import { EraValidatorInfo } from "../src/types";
-import { handlePagedElectionProceeded } from "../src/mappings/NewEra";
+import { handleAHEraPaid } from "../src/mappings/NewEra";
 import {
   SubstrateTestEventBuilder,
   mockOption,
@@ -7,7 +7,8 @@ import {
   mockAddress,
 } from "./utils/mockFunctions";
 
-const CURRENT_ERA = 2228;
+const ACTIVE_ERA = 2227;
+const PLANNED_ERA = 2228;
 
 const VALIDATOR_A = "14LzEeAqYAgVvbxqzdVQGL8zPQFe1o5zGRSbCZDwtCd2AZgA";
 const VALIDATOR_B = "15wD8upZxRZijKkF7JZDdaaFXuRZJhFyYpFQC5j6FaZL5PzA";
@@ -17,7 +18,7 @@ const NOMINATOR_3 = "13FNi4e4EJRpweeTZiUBA4BvjeMKZBxf67h5cyzxxRvHcBMk";
 
 function mockOverviewEntry(validator: string, pageCount: number) {
   return [
-    { args: [mockNumber(CURRENT_ERA), mockAddress(validator)] },
+    { args: [mockNumber(ACTIVE_ERA), mockAddress(validator)] },
     mockOption({
       total: mockNumber(3000),
       own: mockNumber(1000),
@@ -29,7 +30,7 @@ function mockOverviewEntry(validator: string, pageCount: number) {
 function mockPageEntry(validator: string, page: number, others: string[]) {
   return [
     {
-      args: [mockNumber(CURRENT_ERA), mockAddress(validator), mockNumber(page)],
+      args: [mockNumber(ACTIVE_ERA), mockAddress(validator), mockNumber(page)],
     },
     mockOption({
       others: others.map((who) => {
@@ -39,35 +40,45 @@ function mockPageEntry(validator: string, page: number, others: string[]) {
   ];
 }
 
+// At the EraPaid (rotation) block, exposures exist only for the era that just
+// became active; the planned era (currentEra) is not elected yet.
 const mockAPI = {
   query: {
     staking: {
-      currentEra: async () => mockOption(mockNumber(CURRENT_ERA)),
+      activeEra: async () =>
+        mockOption({ index: mockNumber(ACTIVE_ERA), start: mockOption(0) }),
+      currentEra: async () => mockOption(mockNumber(PLANNED_ERA)),
       erasStakersOverview: {
-        entries: async (_era: number) => [
-          mockOverviewEntry(VALIDATOR_A, 2),
-          mockOverviewEntry(VALIDATOR_B, 1),
-        ],
+        entries: async (era: number) =>
+          era === ACTIVE_ERA
+            ? [
+                mockOverviewEntry(VALIDATOR_A, 2),
+                mockOverviewEntry(VALIDATOR_B, 1),
+              ]
+            : [],
       },
       erasStakersPaged: {
-        entries: async (_era: number) => [
-          mockPageEntry(VALIDATOR_A, 0, [NOMINATOR_1]),
-          mockPageEntry(VALIDATOR_A, 1, [NOMINATOR_2]),
-          mockPageEntry(VALIDATOR_B, 0, [NOMINATOR_3]),
-        ],
+        entries: async (era: number) =>
+          era === ACTIVE_ERA
+            ? [
+                mockPageEntry(VALIDATOR_A, 0, [NOMINATOR_1]),
+                mockPageEntry(VALIDATOR_A, 1, [NOMINATOR_2]),
+                mockPageEntry(VALIDATOR_B, 0, [NOMINATOR_3]),
+              ]
+            : [],
       },
     },
   },
 };
 
-function pagedElectionEvent(pageIndex: number) {
+function eraPaidEvent() {
   return new SubstrateTestEventBuilder()
     .withBlock(new Date(), 18040436)
-    .withEvent([mockNumber(pageIndex), mockOption({})], 7)
+    .withEvent([mockNumber(ACTIVE_ERA - 1), mockNumber(1), mockNumber(1)], 7)
     .build();
 }
 
-describe("handlePagedElectionProceeded", () => {
+describe("handleAHEraPaid", () => {
   let savedInfos: EraValidatorInfo[] = [];
 
   beforeAll(() => {
@@ -90,21 +101,17 @@ describe("handlePagedElectionProceeded", () => {
     savedInfos = [];
   });
 
-  it("skips pages other than the last one (page index != 0)", async () => {
-    await handlePagedElectionProceeded(pagedElectionEvent(3));
+  it("snapshots the active era with merged pages and deterministic ids", async () => {
+    jest.spyOn(EraValidatorInfo, "getByEra").mockResolvedValue([]);
 
-    expect(savedInfos).toHaveLength(0);
-  });
-
-  it("saves era validator infos with merged pages on page index 0", async () => {
-    await handlePagedElectionProceeded(pagedElectionEvent(0));
+    await handleAHEraPaid(eraPaidEvent());
 
     expect(savedInfos).toHaveLength(2);
 
     const infoA = savedInfos.find((info) => info.address === VALIDATOR_A);
     expect(infoA).toBeDefined();
-    expect(infoA.id).toBe(`18040436-7${VALIDATOR_A}`);
-    expect(infoA.era).toBe(CURRENT_ERA);
+    expect(infoA.id).toBe(`${ACTIVE_ERA}-${VALIDATOR_A}`);
+    expect(infoA.era).toBe(ACTIVE_ERA);
     expect(infoA.total).toBe(BigInt(3000));
     expect(infoA.own).toBe(BigInt(1000));
     expect(infoA.others.map((other) => other.who)).toEqual([
@@ -114,7 +121,19 @@ describe("handlePagedElectionProceeded", () => {
 
     const infoB = savedInfos.find((info) => info.address === VALIDATOR_B);
     expect(infoB).toBeDefined();
-    expect(infoB.era).toBe(CURRENT_ERA);
+    expect(infoB.id).toBe(`${ACTIVE_ERA}-${VALIDATOR_B}`);
     expect(infoB.others.map((other) => other.who)).toEqual([NOMINATOR_3]);
+  });
+
+  it("skips eras that are already indexed (backfill or earlier run)", async () => {
+    jest
+      .spyOn(EraValidatorInfo, "getByEra")
+      .mockResolvedValue([
+        { id: `${ACTIVE_ERA}-backfill-x` } as EraValidatorInfo,
+      ]);
+
+    await handleAHEraPaid(eraPaidEvent());
+
+    expect(savedInfos).toHaveLength(0);
   });
 });

--- a/westmint.yaml
+++ b/westmint.yaml
@@ -67,11 +67,11 @@ dataSources:
           filter:
             module: staking
             method: Slashed
-        - handler: handlePagedElectionProceeded
+        - handler: handleAHEraPaid
           kind: substrate/EventHandler
           filter:
             module: staking
-            method: PagedElectionProceeded
+            method: EraPaid
         - handler: handlePoolBondedSlash
           kind: substrate/EventHandler
           filter:


### PR DESCRIPTION
Follow-up to #336 (stacked on its branch) — supersedes the PagedElectionProceeded trigger introduced there.

## Problem

Recent staking-async runtimes no longer emit `PagedElectionProceeded` for every page on the **success** path:

- Kusama AH: one event per era with a mid-range page index (`page: 14` — the only election event in 24h of logs), never page 0
- Westend AH: full `31..0` page range emitted only for **failed** attempts (`result: Err(0)`)

So the page-0 gate stops firing. This is exactly why the subquery-staking prod (which has used the page-0 trigger since January) went stale on Westend AH (>3 weeks) and Kusama AH (era 9728, ~June 30) while Polkadot AH still works — the breakage follows the runtime rollout order and reaches Polkadot with its next upgrade.

## Fix

Trigger on `staking.EraPaid` (fires at every rotation on all runtimes) and snapshot **activeEra** — the era that just became active cannot have started without its full exposure set in state. Verified on-chain at the rotation block of all three networks: Polkadot AH `exposures(2227)=600`, Kusama AH `exposures(9780)=700`, Westend AH rotation block carries `EraPaid`. This invariant also holds for the pre-upgrade regime, so a from-scratch reindex stays correct.

Extra hardening:
- deterministic row ids (`<era>-<validator>` instead of `<block>-<eventIdx><validator>`) — re-fires overwrite instead of duplicating
- `getByEra` guard — eras already present (backfill, reindex overlap) are skipped

## Verification

- `yarn test`: 8/8 (handler tests rewritten for the new trigger: activeEra snapshot with merged pages + deterministic ids, and skip-if-era-exists)
- `yarn codegen && yarn build` pass
