### PR TITLE
Fix: getByFields for the era-exists check + explicit fail-fast on missing pages

### DIFF
--- a/src/mappings/NewEra.ts
+++ b/src/mappings/NewEra.ts
@@ -32,7 +32,7 @@ export async function handleStakersElected(
 // Therefore at the EraPaid block exposures(activeEra) are guaranteed complete - an era
 // cannot start without its full validator set. Snapshot activeEra here.
 // The era-exists check guards against double-writes (backfill, reindex).
-export async function handleAHEraPaid(event: SubstrateEvent): Promise<void> {
+export async function handleAHEraPaid(_: SubstrateEvent): Promise<void> {
   const activeEra = (
     (await api.query.staking.activeEra()) as Option<PalletStakingActiveEraInfo>
   )
@@ -129,9 +129,18 @@ async function processEraStakersPaged(currentEra: number): Promise<void> {
     const [, validatorId] = key.args;
     let validatorIdString = validatorId.toString();
 
+    // Fail fast on incomplete exposures: a missing page means the on-chain
+    // invariant is broken, and halting the indexer is better than saving
+    // partial nominator sets silently.
     let others = [];
     for (let i = 0; i < exposure.pageCount.toNumber(); ++i) {
-      others.push(...othersCounted[validatorIdString][i]);
+      const page = othersCounted[validatorIdString]?.[i];
+      if (page === undefined) {
+        throw new Error(
+          `Missing exposure page ${i} for validator ${validatorIdString} in era ${currentEra}`,
+        );
+      }
+      others.push(...page);
     }
 
     const eraValidatorInfo = new EraValidatorInfo(

--- a/src/mappings/NewEra.ts
+++ b/src/mappings/NewEra.ts
@@ -31,7 +31,7 @@ export async function handleStakersElected(
 //
 // Therefore at the EraPaid block exposures(activeEra) are guaranteed complete - an era
 // cannot start without its full validator set. Snapshot activeEra here.
-// getByEra guards against double-writes (backfill, reindex).
+// The era-exists check guards against double-writes (backfill, reindex).
 export async function handleAHEraPaid(event: SubstrateEvent): Promise<void> {
   const activeEra = (
     (await api.query.staking.activeEra()) as Option<PalletStakingActiveEraInfo>
@@ -39,8 +39,13 @@ export async function handleAHEraPaid(event: SubstrateEvent): Promise<void> {
     .unwrap()
     .index.toNumber();
 
-  const existing = await EraValidatorInfo.getByEra(activeEra);
-  if (existing !== undefined && existing.length > 0) {
+  const existing = await EraValidatorInfo.getByFields(
+    [["era", "=", activeEra]],
+    {
+      limit: 1,
+    },
+  );
+  if (existing.length > 0) {
     return;
   }
 

--- a/tests/newEra.test.ts
+++ b/tests/newEra.test.ts
@@ -102,7 +102,7 @@ describe("handleAHEraPaid", () => {
   });
 
   it("snapshots the active era with merged pages and deterministic ids", async () => {
-    jest.spyOn(EraValidatorInfo, "getByEra").mockResolvedValue([]);
+    jest.spyOn(EraValidatorInfo, "getByFields").mockResolvedValue([]);
 
     await handleAHEraPaid(eraPaidEvent());
 
@@ -127,7 +127,7 @@ describe("handleAHEraPaid", () => {
 
   it("skips eras that are already indexed (backfill or earlier run)", async () => {
     jest
-      .spyOn(EraValidatorInfo, "getByEra")
+      .spyOn(EraValidatorInfo, "getByFields")
       .mockResolvedValue([
         { id: `${ACTIVE_ERA}-backfill-x` } as EraValidatorInfo,
       ]);


### PR DESCRIPTION
#338 was merged before its last two commits landed, so the base branch still carries the `getByEra` variant of the era-exists check — and the generated `getByEra` helper does not forward options to `store.getByField`, which **crash-loops subql-node v6** at the first EraPaid block (`Cannot read properties of undefined (reading 'limit')`). Reproduced and verified on a local indexer run against the real Westend AH rotation block 16257472.

Cherry-picks the two missing commits:
- `fix: use getByFields with explicit limit for the era-exists check`
- `chore: fail fast with a descriptive error on missing exposure pages` (keeps the halt-on-broken-invariant behavior, but with an actionable message)

Verified: `yarn test` 8/8, `yarn build` pass; locally replayed the last 5 Polkadot AH era rotations (2226–2230) with this exact code — all eras saved with 600 validators each and nominator sets byte-identical to the on-chain backfill snapshot; zero indexing failures.